### PR TITLE
feat: Add env.example for GoHighLevel configuration

### DIFF
--- a/server/env.example
+++ b/server/env.example
@@ -1,0 +1,8 @@
+# GoHighLevel API Key
+GOHIGHLEVEL_API_KEY=AQUI_VA_TU_API_KEY_DE_GOHIGHLEVEL
+
+# Database configuration (puedes dejar esto como está si usas la configuración por defecto)
+DB_HOST=localhost
+DB_USER=root
+DB_PASSWORD=
+DB_NAME=veterinaria_db


### PR DESCRIPTION
Adds a `server/env.example` file to provide a template for users to configure their GoHighLevel API key and database credentials.